### PR TITLE
schedule backups for docker volumes

### DIFF
--- a/modules/virtualisation/docker-compose.nix
+++ b/modules/virtualisation/docker-compose.nix
@@ -1,10 +1,15 @@
 {
+  self,
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 with lib;
+let
+  inherit (utils.systemdUtils.unitOptions) unitOption;
+in
 {
   options.virtualisation.docker-compose = mkOption {
     type = types.attrsOf (
@@ -19,6 +24,22 @@ with lib;
             default = { };
             description = "Environment variables to write to an .env file";
           };
+          backup = {
+            enable = mkEnableOption "backing up of volumes for these containers";
+            paths = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              description = "Host paths of the volumes to back up";
+            };
+            timerConfig = mkOption {
+              type = types.nullOr (types.attrsOf unitOption);
+              default = {
+                OnCalendar = "01:00";
+                Persistent = true;
+              };
+              description = "Timer config to be passed directly to the restic timer";
+            };
+          };
         };
       }
     );
@@ -26,25 +47,54 @@ with lib;
     description = "Container stacks managed by docker-compose";
   };
 
-  config.systemd.services = mapAttrs' (
-    name: value:
+  config =
     let
-      envLines = mapAttrsToList (k: v: "${k}=${v}") value.env;
+      cfg = config.virtualisation.docker-compose;
+      svcName = composeName: "docker-compose-${composeName}";
     in
-    nameValuePair ("docker-compose-${name}") ({
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "docker.service" ];
-      after = [ "docker.service" ];
-      description = "Docker Compose manager for ${name}";
+    {
+      systemd.services = mapAttrs' (
+        name: value:
+        nameValuePair (svcName name) ({
+          wantedBy = [ "multi-user.target" ];
+          requires = [ "docker.service" ];
+          after = [ "docker.service" ];
+          description = "Docker Compose manager for ${name}";
 
-      serviceConfig = {
-        WorkingDirectory = value.dir;
-        Environment = envLines;
-        ExecStart = "${pkgs.docker-compose}/bin/docker-compose up";
-        ExecStop = "${pkgs.docker-compose}/bin/docker-compose down";
-        ProtectHome = "off";
-        Restart = "always";
+          serviceConfig = {
+            WorkingDirectory = value.dir;
+            Environment = mapAttrsToList (k: v: "${k}=${v}") value.env;
+            ExecStart = "${pkgs.docker-compose}/bin/docker-compose up";
+            ExecStop = "${pkgs.docker-compose}/bin/docker-compose down";
+            ProtectHome = "off";
+            Restart = "always";
+          };
+        })
+      ) cfg;
+
+      services.restic = {
+        enable = true;
+        backups = mapAttrs' (
+          name: value:
+          nameValuePair (name) (
+            mkIf value.backup.enable {
+              initialize = true;
+              paths = value.backup.paths;
+              timerConfig = value.backup.timerConfig // {
+                RandomizedDelaySec = 1800;
+              };
+              repositoryFile = "${self}/secrets/backup/repository";
+              environmentFile = "${self}/secrets/backup/environment";
+              passwordFile = "${self}/secrets/backup/password";
+              extraBackupArgs = [
+                "--tag"
+                name
+              ];
+              backupPrepareCommand = "systemctl stop ${svcName name}.service";
+              backupCleanupCommand = "systemctl start ${svcName name}.service";
+            }
+          )
+        ) cfg;
       };
-    })
-  ) config.virtualisation.docker-compose;
+    };
 }

--- a/stacks/dns/docker-compose.yaml
+++ b/stacks/dns/docker-compose.yaml
@@ -5,8 +5,8 @@ services:
     dns:
       - 9.9.9.9
     volumes:
-      - /home/tyler/apps/pihole/etc-pihole:/etc/pihole
-      - /home/tyler/apps/pihole/etc-dnsmasq:/etc/dnsmasq.d
+      - ${DATA_DIR}:/etc/pihole
+      - ${DNSMASQ_DIR}:/etc/dnsmasq.d
     environment:
       TZ: ${TIMEZONE}
       WEBPASSWORD: ${PASSWORD}

--- a/stacks/feed/docker-compose.yaml
+++ b/stacks/feed/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
       - POSTGRES_DB=miniflux
     volumes:
-      - /home/tyler/apps/miniflux/data:/var/lib/postgresql/data
+      - ${DATA_DIR}:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "miniflux"]
       interval: 10s

--- a/stacks/photos/docker-compose.yaml
+++ b/stacks/photos/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - ${LIBRARY_LOCATION}:/usr/src/app/upload/library
       - ${BACKUP_LOCATION}:/usr/src/app/upload/backups
-      - /home/tyler/shared/safe/data/photos/library-kim:/usr/src/app/library-kim
+      - ${EXTERNAL_LIBRARY_LOCATION}:/usr/src/app/library-kim
       - /etc/localtime:/etc/localtime:ro
     environment:
       DB_PASSWORD: ${DB_PASSWORD}

--- a/stacks/proxy/docker-compose.yaml
+++ b/stacks/proxy/docker-compose.yaml
@@ -5,8 +5,8 @@ services:
       - 80:80
       - 443:443
     volumes:
-      - /home/tyler/apps/nginx/data:/data
-      - /home/tyler/apps/nginx/letsencrypt:/etc/letsencrypt
+      - ${DATA_DIR}:/data
+      - ${LETSENCRYPT_DIR}:/etc/letsencrypt
     networks:
       - private
 

--- a/traits/nixos/backup.nix
+++ b/traits/nixos/backup.nix
@@ -1,19 +1,36 @@
 { self, ... }:
-{
-  services.restic = {
-    enable = true;
-    backups.cloud = {
+let
+  mkBackup =
+    { name, path }:
+    {
       initialize = true;
-      paths = [
-        "/home/tyler/shared/safe"
-      ];
+      paths = [ path ];
       timerConfig = {
         OnCalendar = "01:00";
         Persistent = true;
+        RandomizedDelaySec = 1800;
       };
       repositoryFile = "${self}/secrets/backup/repository";
       environmentFile = "${self}/secrets/backup/environment";
       passwordFile = "${self}/secrets/backup/password";
+      extraBackupArgs = [
+        "--tag"
+        name
+      ];
+    };
+in
+{
+  services.restic = {
+    enable = true;
+    backups = {
+      notes = mkBackup {
+        name = "notes";
+        path = "/home/tyler/shared/safe/data/notes";
+      };
+      records = mkBackup {
+        name = "records";
+        path = "/home/tyler/shared/safe/data/records";
+      };
     };
   };
 }

--- a/traits/nixos/dns.nix
+++ b/traits/nixos/dns.nix
@@ -1,4 +1,8 @@
 { self, ... }:
+let
+  data = "/home/tyler/apps/pihole/etc-pihole";
+  dnsmasq = "/home/tyler/apps/pihole/etc-dnsmasq";
+in
 {
   virtualisation.docker-compose.dns = {
     dir = self + /stacks/dns;
@@ -6,6 +10,19 @@
       TIMEZONE = "America/Chicago";
       PASSWORD = builtins.readFile "${self}/secrets/dns/password";
       TS_AUTHKEY = builtins.readFile "${self}/secrets/dns/authkey";
+      DATA_DIR = data;
+      DNSMASQ_DIR = dnsmasq;
     };
+    /*
+      This does not work because the cloud backup can not be reached when pihole is down
+      backup = {
+        enable = true;
+        paths = [ ];
+        timerConfig = {
+          OnCalendar = "Mon *-*-* 01:00";
+          Persistent = true;
+        };
+      };
+    */
   };
 }

--- a/traits/nixos/feed.nix
+++ b/traits/nixos/feed.nix
@@ -1,11 +1,23 @@
 { self, ... }:
 {
-  config.virtualisation.docker-compose.feed = {
-    dir = self + /stacks/feed;
-    env = {
-      DATA_LOCATION = "home/tyler/apps/miniflux/data";
-      DB_PASSWORD = builtins.readFile (self + /secrets/feed/db-password);
-      API_TOKEN = builtins.readFile (self + /secrets/feed/api-key);
+  config.virtualisation.docker-compose.feed =
+    let
+      dataDir = "/home/tyler/apps/miniflux/data";
+    in
+    {
+      dir = self + /stacks/feed;
+      env = {
+        DATA_DIR = dataDir;
+        DB_PASSWORD = builtins.readFile (self + /secrets/feed/db-password);
+        API_TOKEN = builtins.readFile (self + /secrets/feed/api-key);
+      };
+      backup = {
+        enable = true;
+        paths = [ dataDir ];
+        timerConfig = {
+          OnCalendar = "Mon *-*-* 01:00";
+          Persistent = true;
+        };
+      };
     };
-  };
 }

--- a/traits/nixos/minecraft.nix
+++ b/traits/nixos/minecraft.nix
@@ -1,6 +1,21 @@
 { self, ... }:
+let
+  minecraftDir = "/home/tyler/apps/minecraft/data";
+  netbirdDir = "/home/tyler/apps/netbird/client/data";
+in
 {
   config.virtualisation.docker-compose.minecraft = {
     dir = self + /stacks/minecraft;
+    env = {
+      MINECRAFT_DIR = minecraftDir;
+      NETBIRD_DIR = netbirdDir;
+    };
+    backup = {
+      enable = true;
+      paths = [
+        minecraftDir
+        netbirdDir
+      ];
+    };
   };
 }

--- a/traits/nixos/monitoring.nix
+++ b/traits/nixos/monitoring.nix
@@ -27,9 +27,9 @@
       };
       exporters.restic = lib.mkIf config.services.restic.enable {
         enable = true;
-        repositoryFile = config.services.restic.backups.cloud.repositoryFile;
-        passwordFile = config.services.restic.backups.cloud.passwordFile;
-        environmentFile = config.services.restic.backups.cloud.environmentFile;
+        repositoryFile = config.services.restic.backups.notes.repositoryFile;
+        passwordFile = config.services.restic.backups.notes.passwordFile;
+        environmentFile = config.services.restic.backups.notes.environmentFile;
         refreshInterval = 21600;
       };
     };

--- a/traits/nixos/photos.nix
+++ b/traits/nixos/photos.nix
@@ -1,17 +1,33 @@
 { config, self, ... }:
+let
+  uploadDir = "/home/tyler/apps/immich/upload";
+  libDir = "${config.hostConfig.directories.personalData}/photos/library";
+  extLibDir = "/home/tyler/shared/safe/data/photos/library-kim";
+  dbDir = "/home/tyler/apps/immich/postgres";
+in
 {
   config.virtualisation.docker-compose.photos = {
     dir = self + /stacks/photos;
     env = {
-      UPLOAD_LOCATION = "/home/tyler/apps/immich/upload";
-      LIBRARY_LOCATION = "${config.hostConfig.directories.personalData}/photos/library";
+      UPLOAD_LOCATION = uploadDir;
+      LIBRARY_LOCATION = libDir;
+      EXTERNAL_LIBRARY_LOCATION = extLibDir;
       BACKUP_LOCATION = "${config.hostConfig.directories.appData}/immich";
-      DB_DATA_LOCATION = "/home/tyler/apps/immich/postgres";
+      DB_DATA_LOCATION = dbDir;
       TZ = "America/Chicago";
       IMMICH_VERSION = "v1.134.0";
       DB_DATABASE_NAME = "immich";
       DB_USERNAME = "postgres";
       DB_PASSWORD = builtins.readFile (self + /secrets/photos/db-password);
+    };
+    backup = {
+      enable = true;
+      paths = [
+        uploadDir
+        libDir
+        extLibDir
+        dbDir
+      ];
     };
   };
 }

--- a/traits/nixos/proxy.nix
+++ b/traits/nixos/proxy.nix
@@ -5,7 +5,27 @@
     443
   ];
 
-  virtualisation.docker-compose.proxy = {
-    dir = self + /stacks/proxy;
-  };
+  virtualisation.docker-compose.proxy =
+    let
+      dataDir = "/home/tyler/apps/nginx/data";
+      letsencryptDir = "/home/tyler/apps/nginx/letsencrypt";
+    in
+    {
+      dir = self + /stacks/proxy;
+      env = {
+        DATA_DIR = dataDir;
+        LETSENCRYPT_DIR = letsencryptDir;
+      };
+      backup = {
+        enable = true;
+        paths = [
+          dataDir
+          letsencryptDir
+        ];
+        timerConfig = {
+          OnCalendar = "Mon *-*-* 01:00";
+          Persistent = true;
+        };
+      };
+    };
 }


### PR DESCRIPTION
Add restic backups to the docker compose module and schedule backups for all docker volumes. Additionally modify the original backup trait to run on only the directories that aren't bind mounted.